### PR TITLE
chore(ci) - Update actions base image to node:24

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -14,8 +14,8 @@ jobs:
     name: lint
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6.0.2
+      - uses: actions/setup-go@v6.3.0
         with:
           cache: false
           go-version: '1.21'

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -20,7 +20,7 @@ jobs:
           cache: false
           go-version: '1.21'
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v5
+        uses: golangci/golangci-lint-action@v9.2.0
         with:
           version: 'latest'
           args: '--timeout=60m'

--- a/.github/workflows/revive.yml
+++ b/.github/workflows/revive.yml
@@ -12,9 +12,9 @@ jobs:
   revive:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6.3.0
         with:
           cache: false
           go-version: '1.21'
-      - uses: actions/checkout@v4
-      - uses: morphy2k/revive-action@v2
+      - uses: actions/checkout@v6.0.2
+      - uses: morphy2k/revive-action@v2.7.8

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,12 +8,12 @@ jobs:
   test:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6.3.0
         with:
           cache: false
           go-version: '1.21'
-      - uses: actions/checkout@v4
-      - uses: n8maninger/action-golang-test@v2
+      - uses: actions/checkout@v6.0.2
+      - uses: n8maninger/action-golang-test@v2.1.1
         with:
           args: "-race;-timeout=30m"
 


### PR DESCRIPTION
## Summary
GitHub is enforcing Node.js 24 for GitHub Actions runtime and will block workflows that rely on older Node runtimes.

This PR updates CI workflows to align with the requirement.

## Changes
- Update reusable action references (`uses:`) to latest released versions.
- Update workflow Node container images (`node:<version>`) to `node:24` where they were below 24.